### PR TITLE
New domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,4 @@
 # Deploy
 
 * `export ANIME_API_URL=<ANIME_API_URL>`
-* `export DOMAIN_NAME=<CUSTOM_DOMAIN_NAME>`
 * `cdk deploy`

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@
 
 ## Apitest
 
-* `export API_URL=<WATCH_HISTORY_API_URL>`
 * `export TOKEN=<TEST_USER_TOKEN>`
 * `make apitest`
 
 # Deploy
 
-* `export ANIME_API_URL=<ANIME_API_URL>`
 * `cdk deploy`

--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@
 # Deploy
 
 * `export ANIME_API_URL=<ANIME_API_URL>`
+* `export DOMAIN_NAME=<CUSTOM_DOMAIN_NAME>`
 * `cdk deploy`

--- a/deploy/cdk.py
+++ b/deploy/cdk.py
@@ -12,10 +12,7 @@ app = core.App()
 
 env = {"region": "eu-west-1"}
 
-anime_api_url = os.getenv("ANIME_API_URL")
-if anime_api_url is None:
-    raise RuntimeError("Please set the ANIME_API_URL environment variable")
-
+anime_api_url = "https://api.anime.moshan.tv"
 domain_name = "api.watch-history.moshan.tv"
 
 WatchHistory(app, "watch-history", anime_api_url, domain_name, env=env)

--- a/deploy/cdk.py
+++ b/deploy/cdk.py
@@ -16,9 +16,7 @@ anime_api_url = os.getenv("ANIME_API_URL")
 if anime_api_url is None:
     raise RuntimeError("Please set the ANIME_API_URL environment variable")
 
-domain_name = os.getenv("DOMAIN_NAME")
-if domain_name is None:
-    raise RuntimeError("Please set the DOMAIN_NAME environment variable")
+domain_name = "api.watch-history.moshan.tv"
 
 WatchHistory(app, "watch-history", anime_api_url, domain_name, env=env)
 

--- a/deploy/cdk.py
+++ b/deploy/cdk.py
@@ -12,7 +12,7 @@ app = core.App()
 
 env = {"region": "eu-west-1"}
 
-anime_api_url = "https://api.anime.moshan.tv"
+anime_api_url = "https://api.anime.moshan.tv/v1"
 domain_name = "api.watch-history.moshan.tv"
 
 WatchHistory(app, "watch-history", anime_api_url, domain_name, env=env)

--- a/deploy/cdk.py
+++ b/deploy/cdk.py
@@ -16,6 +16,10 @@ anime_api_url = os.getenv("ANIME_API_URL")
 if anime_api_url is None:
     raise RuntimeError("Please set the ANIME_API_URL environment variable")
 
-WatchHistory(app, "watch-history", anime_api_url, env=env)
+domain_name = os.getenv("DOMAIN_NAME")
+if domain_name is None:
+    raise RuntimeError("Please set the DOMAIN_NAME environment variable")
+
+WatchHistory(app, "watch-history", anime_api_url, domain_name, env=env)
 
 app.synth()

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -201,7 +201,7 @@ class WatchHistory(core.Stack):
             identity_source=["$request.header.Authorization"],
             name="cognito",
             jwt_configuration=CfnAuthorizer.JWTConfigurationProperty(
-                audience=["2uqacp9st5av58h7kfhcq1eoa6"],
+                audience=["68v5rahd0sdvrmf7fgbq2o1a9u"],
                 issuer="https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_sJ3Y4kSv6"
             )
         )

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -263,8 +263,8 @@ class WatchHistory(core.Stack):
             api_id=http_api.http_api_id,
             auto_deploy=True,
             default_route_settings=CfnStage.RouteSettingsProperty(
-                throttling_burst_limit=1,
-                throttling_rate_limit=1
+                throttling_burst_limit=10,
+                throttling_rate_limit=5
             ),
             stage_name="live"
         )

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -4,7 +4,7 @@ import subprocess
 
 from aws_cdk import core
 from aws_cdk.aws_apigatewayv2 import HttpApi, CfnAuthorizer, HttpIntegration, HttpIntegrationType, HttpMethod, \
-    PayloadFormatVersion, CfnRoute, CfnStage
+    PayloadFormatVersion, CfnRoute, CfnStage, HttpApiMapping
 from aws_cdk.aws_dynamodb import Table, Attribute, AttributeType, BillingMode
 from aws_cdk.aws_iam import PolicyStatement, Role, ServicePrincipal, ManagedPolicy
 from aws_cdk.aws_lambda import LayerVersion, Runtime, Function, Code
@@ -227,7 +227,7 @@ class WatchHistory(core.Stack):
                 source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{http_api.http_api_id}/*"
             )
 
-        CfnStage(
+        stage = CfnStage(
             self,
             "live",
             api_id=http_api.http_api_id,
@@ -237,4 +237,12 @@ class WatchHistory(core.Stack):
                 throttling_rate_limit=1
             ),
             stage_name="live"
+        )
+
+        HttpApiMapping(
+            self,
+            "mapping",
+            api=http_api,
+            domain_name=domain_name,
+            stage=stage
         )

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -190,7 +190,7 @@ class WatchHistory(core.Stack):
             cors_preflight=CorsPreflightOptions(
                 allow_methods=[HttpMethod.GET, HttpMethod.POST, HttpMethod.PATCH, HttpMethod.DELETE],
                 allow_origins=["https://moshan.tv"],
-                allow_headers=["authorization"]
+                allow_headers=["authorization", "content-type"]
             )
         )
 

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -42,6 +42,10 @@ class WatchHistory(core.Stack):
             billing_mode=BillingMode.PAY_PER_REQUEST,
         )
         self.watch_history_table.add_local_secondary_index(
+            sort_key=Attribute(name="client_id", type=AttributeType.STRING),
+            index_name="client_id"
+        )
+        self.watch_history_table.add_local_secondary_index(
             sort_key=Attribute(name="rating", type=AttributeType.NUMBER),
             index_name="rating"
         )

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -189,7 +189,8 @@ class WatchHistory(core.Stack):
             create_default_stage=False,
             cors_preflight=CorsPreflightOptions(
                 allow_methods=[HttpMethod.GET, HttpMethod.POST, HttpMethod.PATCH, HttpMethod.DELETE],
-                allow_origins=["https://moshan.tv"]
+                allow_origins=["https://moshan.tv"],
+                allow_headers=["authorization"]
             )
         )
 

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -3,9 +3,9 @@ import shutil
 import subprocess
 
 from aws_cdk import core
-from aws_cdk.aws_apigateway import SecurityPolicy
+from aws_cdk.aws_apigateway import DomainName, SecurityPolicy
 from aws_cdk.aws_apigatewayv2 import HttpApi, CfnAuthorizer, HttpIntegration, HttpIntegrationType, HttpMethod, \
-    PayloadFormatVersion, CfnRoute, CfnStage, HttpApiMapping, DomainName
+    PayloadFormatVersion, CfnRoute, CfnStage, HttpApiMapping
 from aws_cdk.aws_certificatemanager import Certificate, ValidationMethod
 from aws_cdk.aws_dynamodb import Table, Attribute, AttributeType, BillingMode
 from aws_cdk.aws_iam import PolicyStatement, Role, ServicePrincipal, ManagedPolicy

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -19,9 +19,10 @@ BUILD_FOLDER = os.path.join(CURRENT_DIR, "..", "..", "build")
 
 
 class WatchHistory(core.Stack):
-    def __init__(self, app: core.App, id: str, anime_api_url: str, **kwargs) -> None:
+    def __init__(self, app: core.App, id: str, anime_api_url: str, domain_name: str, **kwargs) -> None:
         super().__init__(app, id, **kwargs)
         self.anime_api_url = anime_api_url
+        self.domain_name = domain_name
         self.layers = {}
         self.lambdas = {}
         self._create_tables()

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -5,7 +5,7 @@ import subprocess
 from aws_cdk import core
 from aws_cdk.aws_apigateway import DomainName, SecurityPolicy
 from aws_cdk.aws_apigatewayv2 import HttpApi, CfnAuthorizer, HttpIntegration, HttpIntegrationType, HttpMethod, \
-    PayloadFormatVersion, CfnRoute, CfnStage, HttpApiMapping
+    PayloadFormatVersion, CfnRoute, CfnStage, HttpApiMapping, CorsPreflightOptions
 from aws_cdk.aws_certificatemanager import Certificate, ValidationMethod
 from aws_cdk.aws_dynamodb import Table, Attribute, AttributeType, BillingMode
 from aws_cdk.aws_iam import PolicyStatement, Role, ServicePrincipal, ManagedPolicy
@@ -183,7 +183,15 @@ class WatchHistory(core.Stack):
             security_policy=SecurityPolicy.TLS_1_2
         )
 
-        http_api = HttpApi(self, "watch-history", create_default_stage=False)
+        http_api = HttpApi(
+            self,
+            "watch-history",
+            create_default_stage=False,
+            cors_preflight=CorsPreflightOptions(
+                allow_methods=[HttpMethod.GET, HttpMethod.POST, HttpMethod.PATCH, HttpMethod.DELETE],
+                allow_origins=["https://moshan.tv"]
+            )
+        )
 
         authorizer = CfnAuthorizer(
             self,

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -201,17 +201,17 @@ class WatchHistory(core.Stack):
         routes = {
             "watch_history": {
                 "method": ["GET"],
-                "route": "/watch-history",
+                "route": "/v1/watch-history",
                 "target_lambda": self.lambdas["api-watch_history"]
             },
             "watch_history_by_collection": {
                 "method": ["GET", "POST"],
-                "route": "/watch-history/collection/{collection_name}",
+                "route": "/v1/watch-history/collection/{collection_name}",
                 "target_lambda": self.lambdas["api-watch_history_by_collection"]
             },
             "item_by_collection": {
                 "method": ["GET", "PATCH", "DELETE"],
-                "route": "/watch-history/collection/{collection_name}/{item_id}",
+                "route": "/v1/watch-history/collection/{collection_name}/{item_id}",
                 "target_lambda": self.lambdas["api-item_by_collection"]
             }
 

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -37,7 +37,7 @@ class WatchHistory(core.Stack):
         self.watch_history_table = Table(
             self,
             "watch_history",
-            partition_key=Attribute(name="client_id", type=AttributeType.STRING),
+            partition_key=Attribute(name="username", type=AttributeType.STRING),
             sort_key=Attribute(name="item_id", type=AttributeType.STRING),
             billing_mode=BillingMode.PAY_PER_REQUEST,
         )

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -3,8 +3,10 @@ import shutil
 import subprocess
 
 from aws_cdk import core
+from aws_cdk.aws_apigateway import SecurityPolicy
 from aws_cdk.aws_apigatewayv2 import HttpApi, CfnAuthorizer, HttpIntegration, HttpIntegrationType, HttpMethod, \
-    PayloadFormatVersion, CfnRoute, CfnStage, HttpApiMapping
+    PayloadFormatVersion, CfnRoute, CfnStage, HttpApiMapping, DomainName
+from aws_cdk.aws_certificatemanager import Certificate, ValidationMethod
 from aws_cdk.aws_dynamodb import Table, Attribute, AttributeType, BillingMode
 from aws_cdk.aws_iam import PolicyStatement, Role, ServicePrincipal, ManagedPolicy
 from aws_cdk.aws_lambda import LayerVersion, Runtime, Function, Code
@@ -167,6 +169,20 @@ class WatchHistory(core.Stack):
                 )
 
     def _create_gateway(self):
+        cert = Certificate(
+            self,
+            "certificate",
+            domain_name=self.domain_name,
+            validation_method=ValidationMethod.DNS
+        )
+        domain_name = DomainName(
+            self,
+            "domain",
+            domain_name=self.domain_name,
+            certificate=cert,
+            security_policy=SecurityPolicy.TLS_1_2
+        )
+
         http_api = HttpApi(self, "watch-history", create_default_stage=False)
 
         authorizer = CfnAuthorizer(

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -2,4 +2,4 @@ aws-cdk.core==1.49.1
 aws_cdk.aws_lambda==1.49.1
 aws_cdk.aws_dynamodb==1.49.1
 aws_cdk.aws_iam==1.49.1
-aws_cdk.aws_apigatewayv2==1.49.1
+aws_cdk.aws_apigatewayv2==1.50.0

--- a/src/lambdas/api/item_by_collection/__init__.py
+++ b/src/lambdas/api/item_by_collection/__init__.py
@@ -18,7 +18,7 @@ def handle(event, context):
     log.debug(f"Received event: {event}")
 
     auth_header = event["headers"]["authorization"]
-    client_id = jwt_utils.get_client_id(auth_header)
+    client_id = jwt_utils.get_username(auth_header)
 
     method = event["requestContext"]["http"]["method"]
     collection_name = event["pathParameters"].get("collection_name")

--- a/src/lambdas/api/watch_history/__init__.py
+++ b/src/lambdas/api/watch_history/__init__.py
@@ -12,7 +12,7 @@ ALLOWED_SORT = ["rating", "date_watched", "state"]
 
 def handle(event, context):
     auth_header = event["headers"]["authorization"]
-    client_id = jwt_utils.get_client_id(auth_header)
+    client_id = jwt_utils.get_username(auth_header)
 
     sort = None
     query_params = event.get("queryStringParameters")

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -68,13 +68,10 @@ def _get_watch_history(client_id, collection_name, query_params, token):
 
         # Fetch anime posters for all items in returned watch_history items
         if collection_name == "anime":
-            ids = []
-            for item in watch_history["items"]:
-                ids.append(item["item_id"])
+            anime = anime_api.get_anime(watch_history.keys(), token)
 
-            posters_response = anime_api.get_posters(ids, token)
-            for anime_id in posters_response:
-                watch_history["items"][anime_id] = posters_response[anime_id]
+            for anime_id in anime:
+                watch_history["items"][anime_id] = anime[anime_id]
 
         return {"statusCode": 200, "body": json.dumps(watch_history, cls=decimal_encoder.DecimalEncoder)}
     except watch_history_db.NotFoundError:

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -18,7 +18,7 @@ POST_SCHEMA_PATH = os.path.join(CURRENT_DIR, "post.json")
 def handle(event, context):
     log.debug(f"Received event: {event}")
     auth_header = event["headers"]["authorization"]
-    client_id = jwt_utils.get_client_id(auth_header)
+    client_id = jwt_utils.get_username(auth_header)
 
     collection_name = event["pathParameters"].get("collection_name")
 

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -68,7 +68,7 @@ def _get_watch_history(client_id, collection_name, query_params, token):
 
         # Fetch anime posters for all items in returned watch_history items
         if collection_name == "anime":
-            anime = anime_api.get_anime(watch_history.keys(), token)
+            anime = anime_api.get_anime(watch_history["items"].keys(), token)
 
             for anime_id in anime:
                 watch_history["items"][anime_id] = anime[anime_id]

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -70,7 +70,7 @@ def _get_watch_history(client_id, collection_name, query_params, token):
         if collection_name == "anime":
             ids = []
             for item in watch_history["items"]:
-                ids.append(item["id"])
+                ids.append(item["item_id"])
 
             posters_response = anime_api.get_posters(ids, token)
             for anime_id in posters_response:

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -16,6 +16,7 @@ POST_SCHEMA_PATH = os.path.join(CURRENT_DIR, "post.json")
 
 
 def handle(event, context):
+    log.debug(f"Received event: {event}")
     auth_header = event["headers"]["authorization"]
     client_id = jwt_utils.get_client_id(auth_header)
 

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -71,7 +71,7 @@ def _get_watch_history(client_id, collection_name, query_params, token):
             anime = anime_api.get_anime(watch_history["items"].keys(), token)
 
             for anime_id in anime:
-                watch_history["items"][anime_id] = anime[anime_id]
+                watch_history["items"][anime_id].update(anime[anime_id])
 
         return {"statusCode": 200, "body": json.dumps(watch_history, cls=decimal_encoder.DecimalEncoder)}
     except watch_history_db.NotFoundError:

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -70,6 +70,7 @@ def _post_collection_item(client_id, collection_name, body, token):
     try:
         body = json.loads(body)
     except (TypeError, JSONDecodeError):
+        log.debug(f"Invalid body: {body}")
         return {
             "statusCode": 400,
             "body": "Invalid post body"

--- a/src/layers/api/python/anime_api.py
+++ b/src/layers/api/python/anime_api.py
@@ -21,9 +21,9 @@ def post_anime(mal_id, token):
     return res.json()["anime_id"]
 
 
-def get_posters(ids, token):
+def get_anime(ids, token):
     ids = ",".join(ids)
-    res = requests.get(f"{ANIME_API_URL}/anime/{ids}/posters", headers={"Authorization": token})
+    res = requests.get(f"{ANIME_API_URL}/anime/{ids}", headers={"Authorization": token})
     if res.status_code != 200:
         raise HttpError(f"Invalid response: {res.status_code}")
 

--- a/src/layers/api/python/anime_api.py
+++ b/src/layers/api/python/anime_api.py
@@ -23,7 +23,7 @@ def post_anime(mal_id, token):
 
 def get_posters(ids, token):
     ids = ",".join(ids)
-    res = requests.get(f"{ANIME_API_URL}/{ids}/posters", header={"Authorization": token})
+    res = requests.get(f"{ANIME_API_URL}/anime/{ids}/posters", headers={"Authorization": token})
     if res.status_code != 200:
         raise HttpError(f"Invalid response: {res.status_code}")
 

--- a/src/layers/api/python/anime_api.py
+++ b/src/layers/api/python/anime_api.py
@@ -19,3 +19,11 @@ def post_anime(mal_id, token):
         raise HttpError(f"Invalid response: {res.status_code}")
 
     return res.json()["anime_id"]
+
+
+def get_posters(ids, token):
+    res = requests.get(f"{ANIME_API_URL}/{ids}/posters", header={"Authorization": token})
+    if res.status_code != 200:
+        raise HttpError(f"Invalid response: {res.status_code}")
+
+    return res.json()

--- a/src/layers/api/python/anime_api.py
+++ b/src/layers/api/python/anime_api.py
@@ -22,6 +22,7 @@ def post_anime(mal_id, token):
 
 
 def get_posters(ids, token):
+    ids = ",".join(ids)
     res = requests.get(f"{ANIME_API_URL}/{ids}/posters", header={"Authorization": token})
     if res.status_code != 200:
         raise HttpError(f"Invalid response: {res.status_code}")

--- a/src/layers/databases/python/watch_history_db.py
+++ b/src/layers/databases/python/watch_history_db.py
@@ -152,7 +152,9 @@ def _watch_history_generator(username, limit, collection_name=None, index_name=N
     page_iterator = paginator.paginate(**query_kwargs)
 
     for p in page_iterator:
-        items = []
+        items = {}
         for i in p["Items"]:
-            items.append(json_util.loads(i))
+            item = json_util.loads(i)
+            item_id = item.pop("item_id")
+            items[item_id] = item
         yield items

--- a/src/layers/databases/python/watch_history_db.py
+++ b/src/layers/databases/python/watch_history_db.py
@@ -42,24 +42,24 @@ def _get_client():
     return client
 
 
-def add_item(client_id, collection_name, item_id):
+def add_item(username, collection_name, item_id):
     data = {}
     try:
-        get_item(client_id, collection_name, item_id)
+        get_item(username, collection_name, item_id)
     except NotFoundError:
         data["created_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    update_item(client_id, collection_name, item_id, data)
+    update_item(username, collection_name, item_id, data)
 
 
-def delete_item(client_id, collection_name, item_id):
+def delete_item(username, collection_name, item_id):
     data = {"deleted_at": int(time.time())}
-    update_item(client_id, collection_name, item_id, data)
+    update_item(username, collection_name, item_id, data)
 
 
-def get_item(client_id, collection_name, item_id):
+def get_item(username, collection_name, item_id):
     res = _get_table().query(
-        KeyConditionExpression=Key("client_id").eq(client_id) & Key("item_id").eq(item_id),
+        KeyConditionExpression=Key("username").eq(username) & Key("item_id").eq(item_id),
         FilterExpression=Attr("collection_name").eq(collection_name) & Attr("deleted_at").not_exists(),
     )
 
@@ -69,7 +69,7 @@ def get_item(client_id, collection_name, item_id):
     return res["Items"][0]
 
 
-def update_item(client_id, collection_name, item_id, data):
+def update_item(username, collection_name, item_id, data):
     data["collection_name"] = collection_name
     data["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -85,11 +85,11 @@ def update_item(client_id, collection_name, item_id, data):
     log.debug(f"Update expression: {update_expression}")
     log.debug(f"Expression attribute names: {expression_attribute_names}")
     log.debug(f"Expression attribute values: {expression_attribute_values}")
-    log.debug(f"Client ID: {client_id}")
+    log.debug(f"Client ID: {username}")
 
     _get_table().update_item(
         Key={
-            "client_id": client_id,
+            "username": username,
             "item_id": item_id,
         },
         UpdateExpression=update_expression,
@@ -98,7 +98,7 @@ def update_item(client_id, collection_name, item_id, data):
     )
 
 
-def get_watch_history(client_id, collection_name=None, index_name=None, limit=100, start=1):
+def get_watch_history(username, collection_name=None, index_name=None, limit=100, start=1):
     start_page = 0
     res = []
 
@@ -106,7 +106,7 @@ def get_watch_history(client_id, collection_name=None, index_name=None, limit=10
         raise InvalidStartOffset
 
     total_pages = 0
-    for p in _watch_history_generator(client_id, limit=limit, collection_name=collection_name, index_name=index_name):
+    for p in _watch_history_generator(username,limit=limit, collection_name=collection_name, index_name=index_name):
         total_pages += 1
         start_page += 1
         if start_page == start:
@@ -119,7 +119,7 @@ def get_watch_history(client_id, collection_name=None, index_name=None, limit=10
 
     if not res:
         raise NotFoundError(
-            f"Watch history for client with id: {client_id} and collection: {collection_name} not found")
+            f"Watch history for client with id: {username} and collection: {collection_name} not found")
 
     return {
         "items": res,
@@ -127,14 +127,14 @@ def get_watch_history(client_id, collection_name=None, index_name=None, limit=10
     }
 
 
-def _watch_history_generator(client_id, limit, collection_name=None, index_name=None):
+def _watch_history_generator(username, limit, collection_name=None, index_name=None):
     paginator = _get_client().get_paginator('query')
 
     query_kwargs = {
         "TableName": DATABASE_NAME,
-        "KeyConditionExpression": "client_id = :client_id",
+        "KeyConditionExpression": "username = :username",
         "ExpressionAttributeValues": {
-            ":client_id": {"S": client_id}
+            ":username": {"S": username}
         },
         "Limit": limit,
         "ScanIndexForward": False,

--- a/src/layers/databases/python/watch_history_db.py
+++ b/src/layers/databases/python/watch_history_db.py
@@ -115,7 +115,7 @@ def get_watch_history(username, collection_name=None, index_name=None, limit=100
     if start > start_page:
         raise InvalidStartOffset
 
-    log.debug(f"get_episodes response: {res}")
+    log.debug(f"get_watch_history response: {res}")
 
     if not res:
         raise NotFoundError(

--- a/src/layers/databases/python/watch_history_db.py
+++ b/src/layers/databases/python/watch_history_db.py
@@ -106,7 +106,7 @@ def get_watch_history(username, collection_name=None, index_name=None, limit=100
         raise InvalidStartOffset
 
     total_pages = 0
-    for p in _watch_history_generator(username,limit=limit, collection_name=collection_name, index_name=index_name):
+    for p in _watch_history_generator(username, limit=limit, collection_name=collection_name, index_name=index_name):
         total_pages += 1
         start_page += 1
         if start_page == start:

--- a/src/layers/utils/python/jwt_utils.py
+++ b/src/layers/utils/python/jwt_utils.py
@@ -1,7 +1,7 @@
 import jwt
 
 
-def get_client_id(jwt_str):
+def get_username(jwt_str):
     # Verification done by apigw
     decoded = jwt.decode(jwt_str, verify=False)
-    return decoded["client_id"]
+    return decoded["username"]

--- a/test/apitest/conftest.py
+++ b/test/apitest/conftest.py
@@ -1,6 +1,6 @@
 import os
 
-API_URL = os.getenv("API_URL")
+API_URL = "https://api.watch-history.moshan.tv"
 BASE_HEADERS = {
     "Authorization": os.getenv("TOKEN")
 }

--- a/test/unittest/test_item_by_collection.py
+++ b/test/unittest/test_item_by_collection.py
@@ -4,7 +4,7 @@ from api.item_by_collection import handle
 from watch_history_db import NotFoundError
 
 TEST_CLIENT_ID = "TEST_CLIENT_ID"
-TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJjbGllbnRfaWQiOiJURVNUX0NMSUVOVF9JRCJ9.tmBhM3qCJrWJ-bebHXsO9lfmNbF7kYGvMH_qbzNojZQ"
+TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VybmFtZSI6IlRFU1RfQ0xJRU5UX0lEIn0.ud_dRdguJwmKv4XO-c4JD-dKGffSvXsxuAxZq9uWV-g"
 
 
 @patch("api.item_by_collection.watch_history_db.get_item")

--- a/test/unittest/test_watch_history.py
+++ b/test/unittest/test_watch_history.py
@@ -6,7 +6,7 @@ from api.watch_history import ALLOWED_SORT, handle
 from watch_history_db import NotFoundError
 
 TEST_CLIENT_ID = "TEST_CLIENT_ID"
-TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJjbGllbnRfaWQiOiJURVNUX0NMSUVOVF9JRCJ9.tmBhM3qCJrWJ-bebHXsO9lfmNbF7kYGvMH_qbzNojZQ"
+TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VybmFtZSI6IlRFU1RfQ0xJRU5UX0lEIn0.ud_dRdguJwmKv4XO-c4JD-dKGffSvXsxuAxZq9uWV-g"
 
 
 @patch("api.watch_history.watch_history_db.get_watch_history")

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -12,8 +12,16 @@ TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VybmFtZSI6IlRFU
 
 
 @patch("api.watch_history_by_collection.watch_history_db.get_watch_history")
-def test_handler(mocked_get_watch_history):
-    mocked_get_watch_history.return_value = [{"collection_name": "anime", "item_id": Decimal(123)}]
+@patch("api.watch_history_by_collection.anime_api.get_anime")
+def test_handler(mocked_get_anime, mocked_get_watch_history):
+    mocked_get_watch_history.return_value = {
+        "items": {"123": {"collection_name": "anime", "item_id": Decimal(123)}}
+    }
+    mocked_get_anime.return_value = {
+        "123": {
+            "title": "anime_title"
+        }
+    }
 
     event = {
         "headers": {
@@ -30,7 +38,10 @@ def test_handler(mocked_get_watch_history):
     }
 
     ret = handle(event, None)
-    assert ret == {"body": '[{"collection_name": "anime", "item_id": 123}]', "statusCode": 200}
+    assert ret == {
+        'body': '{"items": {"123": {"collection_name": "anime", "item_id": 123, "title": "anime_title"}}}',
+        "statusCode": 200
+    }
 
 
 def test_handler_invalid_sort():
@@ -61,7 +72,7 @@ def test_handler_invalid_sort():
 
 @patch("api.watch_history_by_collection.watch_history_db.get_watch_history")
 def test_handler_sort(mocked_get_watch_history):
-    mocked_get_watch_history.return_value = [{"collection_name": "anime", "item_id": Decimal(123)}]
+    mocked_get_watch_history.return_value = [{"collection_name": "test_collection", "item_id": Decimal(123)}]
 
     event = {
         "headers": {
@@ -71,7 +82,7 @@ def test_handler_sort(mocked_get_watch_history):
             "sort": "date_watched"
         },
         "pathParameters": {
-            "collection_name": "anime"
+            "collection_name": "test_collection"
         },
         "requestContext": {
             "http": {
@@ -82,12 +93,12 @@ def test_handler_sort(mocked_get_watch_history):
 
     ret = handle(event, None)
 
-    assert ret == {'body': '[{"collection_name": "anime", "item_id": 123}]', 'statusCode': 200}
+    assert ret == {'body': '[{"collection_name": "test_collection", "item_id": 123}]', 'statusCode': 200}
 
 
 @patch("api.watch_history_by_collection.watch_history_db.get_watch_history")
 def test_handler_limit_and_start(mocked_get_watch_history):
-    mocked_get_watch_history.return_value = [{"collection_name": "anime", "item_id": Decimal(123)}]
+    mocked_get_watch_history.return_value = [{"collection_name": "test_collection", "item_id": Decimal(123)}]
 
     event = {
         "headers": {
@@ -98,7 +109,7 @@ def test_handler_limit_and_start(mocked_get_watch_history):
             "start": "23"
         },
         "pathParameters": {
-            "collection_name": "anime"
+            "collection_name": "test_collection"
         },
         "requestContext": {
             "http": {
@@ -109,7 +120,7 @@ def test_handler_limit_and_start(mocked_get_watch_history):
 
     ret = handle(event, None)
 
-    assert ret == {'body': '[{"collection_name": "anime", "item_id": 123}]', 'statusCode': 200}
+    assert ret == {'body': '[{"collection_name": "test_collection", "item_id": 123}]', 'statusCode': 200}
 
 
 def test_handler_invalid_limit_type():

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -8,7 +8,7 @@ from schema import ALLOWED_SORT
 from watch_history_db import NotFoundError
 
 TEST_CLIENT_ID = "TEST_CLIENT_ID"
-TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJjbGllbnRfaWQiOiJURVNUX0NMSUVOVF9JRCJ9.tmBhM3qCJrWJ-bebHXsO9lfmNbF7kYGvMH_qbzNojZQ"
+TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VybmFtZSI6IlRFU1RfQ0xJRU5UX0lEIn0.ud_dRdguJwmKv4XO-c4JD-dKGffSvXsxuAxZq9uWV-g"
 
 
 @patch("api.watch_history_by_collection.watch_history_db.get_watch_history")

--- a/test/unittest/test_watch_history_db.py
+++ b/test/unittest/test_watch_history_db.py
@@ -137,7 +137,7 @@ def test_get_watch_history_by_with_start(mocked_watch_history_db):
         "TableName": None
     }
     assert ret == {
-        "items": [{"collection_name": "MOVIE", "item_id": 123}],
+        'items': {123: {'collection_name': 'MOVIE'}},
         "total_pages": 2
     }
 

--- a/test/unittest/test_watch_history_db.py
+++ b/test/unittest/test_watch_history_db.py
@@ -6,7 +6,7 @@ import pytest
 
 UPDATE_VALUES = {}
 MOCK_RETURN = []
-TEST_CLIENT_ID = "TEST_CLIENT_ID"
+TEST_USERNAME = "TEST_USERNAME"
 
 
 def mock_func(**kwargs):
@@ -26,12 +26,12 @@ def test_get_watch_history(mocked_watch_history_db):
     mocked_watch_history_db.client.get_paginator.return_value = m
     m.paginate = mock_func
 
-    mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID)
+    mocked_watch_history_db.get_watch_history(TEST_USERNAME)
 
     assert UPDATE_VALUES == {
         "TableName": None,
-        "KeyConditionExpression": "client_id = :client_id",
-        "ExpressionAttributeValues": {":client_id": {"S": "TEST_CLIENT_ID"}},
+        "KeyConditionExpression": "username = :username",
+        "ExpressionAttributeValues": {":username": {"S": "TEST_USERNAME"}},
         "Limit": 100,
         "ScanIndexForward": False,
         'FilterExpression': 'attribute_not_exists(deleted_at)',
@@ -48,12 +48,12 @@ def test_get_watch_history_changed_limit(mocked_watch_history_db):
     mocked_watch_history_db.client.get_paginator.return_value = m
     m.paginate = mock_func
 
-    mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID, limit=10)
+    mocked_watch_history_db.get_watch_history(TEST_USERNAME, limit=10)
 
     assert UPDATE_VALUES == {
         "TableName": None,
-        "KeyConditionExpression": "client_id = :client_id",
-        "ExpressionAttributeValues": {":client_id": {"S": "TEST_CLIENT_ID"}},
+        "KeyConditionExpression": "username = :username",
+        "ExpressionAttributeValues": {":username": {"S": "TEST_USERNAME"}},
         "Limit": 10,
         "ScanIndexForward": False,
         'FilterExpression': 'attribute_not_exists(deleted_at)',
@@ -69,15 +69,15 @@ def test_get_watch_history_by_collection_name(mocked_watch_history_db):
     mocked_watch_history_db.client.get_paginator.return_value = m
     m.paginate = mock_func
 
-    mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID, collection_name="ANIME", limit=10)
+    mocked_watch_history_db.get_watch_history(TEST_USERNAME, collection_name="ANIME", limit=10)
 
     assert UPDATE_VALUES == {
         "ExpressionAttributeValues": {
-            ":client_id": {"S": "TEST_CLIENT_ID"},
+            ":username": {"S": "TEST_USERNAME"},
             ":collection_name": {"S": "ANIME"}
         },
         "FilterExpression": "attribute_not_exists(deleted_at) and collection_name = :collection_name",
-        "KeyConditionExpression": "client_id = :client_id",
+        "KeyConditionExpression": "username = :username",
         "Limit": 10,
         "ScanIndexForward": False,
         "TableName": None,
@@ -94,16 +94,16 @@ def test_get_watch_history_by_collection_and_index(mocked_watch_history_db):
     mocked_watch_history_db.client.get_paginator.return_value = m
     m.paginate = mock_func
 
-    mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID, collection_name="ANIME", index_name="test_index",
+    mocked_watch_history_db.get_watch_history(TEST_USERNAME, collection_name="ANIME", index_name="test_index",
                                               limit=10)
 
     assert UPDATE_VALUES == {
         "ExpressionAttributeValues": {
-            ":client_id": {"S": "TEST_CLIENT_ID"},
+            ":username": {"S": "TEST_USERNAME"},
             ":collection_name": {"S": "ANIME"}
         },
         "FilterExpression": "attribute_not_exists(deleted_at) and collection_name = :collection_name",
-        "KeyConditionExpression": "client_id = :client_id",
+        "KeyConditionExpression": "username = :username",
         "Limit": 10,
         "IndexName": "test_index",
         "ScanIndexForward": False,
@@ -121,16 +121,16 @@ def test_get_watch_history_by_with_start(mocked_watch_history_db):
     mocked_watch_history_db.client.get_paginator.return_value = m
     m.paginate = mock_func
 
-    ret = mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID, collection_name="ANIME", index_name="test_index",
+    ret = mocked_watch_history_db.get_watch_history(TEST_USERNAME, collection_name="ANIME", index_name="test_index",
                                                     limit=1, start=2)
 
     assert UPDATE_VALUES == {
         "ExpressionAttributeValues": {
-            ":client_id": {"S": "TEST_CLIENT_ID"},
+            ":username": {"S": "TEST_USERNAME"},
             ":collection_name": {"S": "ANIME"}
         },
         "FilterExpression": "attribute_not_exists(deleted_at) and collection_name = :collection_name",
-        "KeyConditionExpression": "client_id = :client_id",
+        "KeyConditionExpression": "username = :username",
         "Limit": 1,
         "IndexName": "test_index",
         "ScanIndexForward": False,
@@ -144,7 +144,7 @@ def test_get_watch_history_by_with_start(mocked_watch_history_db):
 
 def test_get_watch_history_too_small_start_index(mocked_watch_history_db):
     with pytest.raises(mocked_watch_history_db.InvalidStartOffset):
-        mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID, start=0)
+        mocked_watch_history_db.get_watch_history(TEST_USERNAME, start=0)
 
 
 def test_get_watch_history_too_large_start_index(mocked_watch_history_db):
@@ -157,7 +157,7 @@ def test_get_watch_history_too_large_start_index(mocked_watch_history_db):
     mocked_watch_history_db.client.get_paginator.return_value = m
     m.paginate = mock_func
     with pytest.raises(mocked_watch_history_db.InvalidStartOffset):
-        mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID, start=10)
+        mocked_watch_history_db.get_watch_history(TEST_USERNAME, start=10)
 
 
 def test_get_watch_history_not_found(mocked_watch_history_db):
@@ -166,7 +166,7 @@ def test_get_watch_history_not_found(mocked_watch_history_db):
     m.paginate.return_value = [{"Items": []}]
 
     with pytest.raises(mocked_watch_history_db.NotFoundError):
-        mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID)
+        mocked_watch_history_db.get_watch_history(TEST_USERNAME)
 
 
 def test_get_watch_history_by_collection_not_found(mocked_watch_history_db):
@@ -175,7 +175,7 @@ def test_get_watch_history_by_collection_not_found(mocked_watch_history_db):
     m.paginate.return_value = [{"Items": []}]
 
     with pytest.raises(mocked_watch_history_db.NotFoundError):
-        mocked_watch_history_db.get_watch_history(TEST_CLIENT_ID, "ANIME")
+        mocked_watch_history_db.get_watch_history(TEST_USERNAME, "ANIME")
 
 
 def test_add_item(mocked_watch_history_db):
@@ -184,7 +184,7 @@ def test_add_item(mocked_watch_history_db):
     mocked_watch_history_db.table.update_item = mock_func
     mocked_watch_history_db.table.query.side_effect = mocked_watch_history_db.NotFoundError
 
-    mocked_watch_history_db.add_item(TEST_CLIENT_ID, "MOVIE", "123123")
+    mocked_watch_history_db.add_item(TEST_USERNAME, "MOVIE", "123123")
 
     assert UPDATE_VALUES == {
         'ExpressionAttributeNames': {
@@ -198,7 +198,7 @@ def test_add_item(mocked_watch_history_db):
             ":updated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         },
         'Key': {
-            'client_id': TEST_CLIENT_ID,
+            'username': TEST_USERNAME,
             'item_id': '123123'},
         'UpdateExpression': 'SET #created_at=:created_at,#collection_name=:collection_name,#updated_at=:updated_at REMOVE deleted_at'
     }
@@ -212,7 +212,7 @@ def test_add_item_already_exists(mocked_watch_history_db):
         "Items": [{"exists"}]
     }
 
-    mocked_watch_history_db.add_item(TEST_CLIENT_ID, "MOVIE", "123123")
+    mocked_watch_history_db.add_item(TEST_USERNAME, "MOVIE", "123123")
 
     assert UPDATE_VALUES == {
         'ExpressionAttributeNames': {
@@ -224,7 +224,7 @@ def test_add_item_already_exists(mocked_watch_history_db):
             ':updated_at': datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         },
         'Key': {
-            'client_id': 'TEST_CLIENT_ID',
+            'username': 'TEST_USERNAME',
             'item_id': '123123'
         },
         'UpdateExpression': 'SET #collection_name=:collection_name,#updated_at=:updated_at REMOVE deleted_at'
@@ -236,7 +236,7 @@ def test_update_item(mocked_watch_history_db):
     UPDATE_VALUES = {}
     mocked_watch_history_db.table.update_item = mock_func
 
-    mocked_watch_history_db.add_item(TEST_CLIENT_ID, "MOVIE", "123123")
+    mocked_watch_history_db.add_item(TEST_USERNAME, "MOVIE", "123123")
 
     assert UPDATE_VALUES == {
         'ExpressionAttributeNames': {
@@ -248,7 +248,7 @@ def test_update_item(mocked_watch_history_db):
             ":updated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         },
         'Key': {
-            'client_id': TEST_CLIENT_ID,
+            'username': TEST_USERNAME,
             'item_id': '123123'},
         'UpdateExpression': 'SET #collection_name=:collection_name,#updated_at=:updated_at REMOVE deleted_at'
     }
@@ -259,7 +259,7 @@ def test_delete_item(mocked_watch_history_db):
     UPDATE_VALUES = {}
     mocked_watch_history_db.table.update_item = mock_func
 
-    mocked_watch_history_db.delete_item(TEST_CLIENT_ID, "MOVIE", "123123")
+    mocked_watch_history_db.delete_item(TEST_USERNAME, "MOVIE", "123123")
 
     assert UPDATE_VALUES == {
         'ExpressionAttributeNames': {
@@ -273,7 +273,7 @@ def test_delete_item(mocked_watch_history_db):
             ':updated_at': datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         },
         'Key': {
-            'client_id': TEST_CLIENT_ID,
+            'username': TEST_USERNAME,
             'item_id': '123123'
         },
         'UpdateExpression': 'SET #deleted_at=:deleted_at,#collection_name=:collection_name,#updated_at=:updated_at'
@@ -288,7 +288,7 @@ def test_add_item_exists(mocked_watch_history_db):
         "Items": [{"item_data"}]
     }
 
-    mocked_watch_history_db.add_item(TEST_CLIENT_ID, "MOVIE", "123123")
+    mocked_watch_history_db.add_item(TEST_USERNAME, "MOVIE", "123123")
 
     assert UPDATE_VALUES == {
         'ExpressionAttributeNames': {
@@ -300,7 +300,7 @@ def test_add_item_exists(mocked_watch_history_db):
             ':updated_at': datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         },
         'Key': {
-            'client_id': TEST_CLIENT_ID, 'item_id': '123123'},
+            'username': TEST_USERNAME, 'item_id': '123123'},
         'UpdateExpression': 'SET #collection_name=:collection_name,#updated_at=:updated_at REMOVE deleted_at'}
 
 
@@ -310,7 +310,7 @@ def test_get_item(mocked_watch_history_db):
 
     mocked_watch_history_db.table.query = mock_func
 
-    ret = mocked_watch_history_db.get_item(TEST_CLIENT_ID, "MOVIE", "123123")
+    ret = mocked_watch_history_db.get_item(TEST_USERNAME, "MOVIE", "123123")
 
     assert ret == {'collection_name': 'ANIME', 'item_id': 123}
 
@@ -319,4 +319,4 @@ def test_get_item_not_found(mocked_watch_history_db):
     mocked_watch_history_db.table.query.return_value = {"Items": []}
 
     with pytest.raises(mocked_watch_history_db.NotFoundError):
-        mocked_watch_history_db.get_item(TEST_CLIENT_ID, "MOVIE", "123123")
+        mocked_watch_history_db.get_item(TEST_USERNAME, "MOVIE", "123123")


### PR DESCRIPTION
Add support (and requirements) for deploying with domain name for the apigateway together with a certificate

Extras:

* Prefix all routes with version v1
* Bump apigatewayv2 lib to `1.50.0`
* Hardcode `ANIME_API_URL` to `api.anime.moshan.tv`
* Hardcode `DOMAIN_NAME` to `api.watch-history.moshan.tv`
* Use unique cognito username as primary key in watch-history DynamoDb table
* Add CORS settings for `https://moshan.tv` domain to watch-history gateway
* Join anime data (poster, title, start_date) in response of `GET /v1/watch-history/collections/anime`
* Return map of `item_id`'s to data in `GET /v1/watch-history/collections/anime` response
