### PR TITLE
Set layer names

### DIFF
--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -167,6 +167,7 @@ class WatchHistory(core.Stack):
             self.layers[layer] = LayerVersion(
                 self,
                 layer,
+                layer_version_name=f"watch-history-{layer}",
                 code=Code.from_asset(path=build_folder),
                 compatible_runtimes=[Runtime.PYTHON_3_8],
             )

--- a/src/lambdas/api/episode_by_id/patch.json
+++ b/src/lambdas/api/episode_by_id/patch.json
@@ -46,7 +46,8 @@
       "description": "One or more dates this episode was watched",
       "items": {
         "type": "string",
-        "format": "date-time"
+        "format": "date-time",
+        "minLength": 5
       }
     }
   }


### PR DESCRIPTION
* Hardcode layer names to  `watch-history-<LAYER_NAME>` in order to not collide with other services
* Set min length of watch date to 5 chars