### PR TITLE
Show api item implementation

### DIFF
--- a/deploy/cdk.py
+++ b/deploy/cdk.py
@@ -13,8 +13,9 @@ app = core.App()
 env = {"region": "eu-west-1"}
 
 anime_api_url = "https://api.anime.moshan.tv/v1"
+show_api_url = "https://api.show.moshan.tv/v1"
 domain_name = "api.watch-history.moshan.tv"
 
-WatchHistory(app, "watch-history", anime_api_url, domain_name, env=env)
+WatchHistory(app, "watch-history", anime_api_url, show_api_url, domain_name, env=env)
 
 app.synth()

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -21,9 +21,10 @@ BUILD_FOLDER = os.path.join(CURRENT_DIR, "..", "..", "build")
 
 
 class WatchHistory(core.Stack):
-    def __init__(self, app: core.App, id: str, anime_api_url: str, domain_name: str, **kwargs) -> None:
+    def __init__(self, app: core.App, id: str, anime_api_url: str, show_api_url: str, domain_name: str, **kwargs) -> None:
         super().__init__(app, id, **kwargs)
         self.anime_api_url = anime_api_url
+        self.show_api_url = show_api_url
         self.domain_name = domain_name
         self.layers = {}
         self.lambdas = {}
@@ -88,7 +89,8 @@ class WatchHistory(core.Stack):
                 "variables": {
                     "DATABASE_NAME": self.watch_history_table.table_name,
                     "LOG_LEVEL": "INFO",
-                    "ANIME_API_URL": self.anime_api_url
+                    "ANIME_API_URL": self.anime_api_url,
+                    "SHOWS_API_URL": self.show_api_url
                 },
                 "concurrent_executions": 10,
                 "policies": [

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -113,7 +113,9 @@ def _post_collection_item(username, collection_name, body, token):
         elif collection_name == "movie":
             return {"statusCode": 501}  # TODO: Implement
     except api_errors.HttpError as e:
-        return {"statusCode": 503, "body": json.dumps({"message": "Error during anime post", "error": str(e)})}
+        err_msg = f"Could not post {collection_name}"
+        log.error(f"{err_msg}. Error: {str(e)}")
+        return {"statusCode": e.status_code, "body": json.dumps({"message": err_msg}), "error": str(e)}
 
     watch_history_db.add_item(username, collection_name, item_id)
     return {"statusCode": 204}

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -101,19 +101,16 @@ def _post_collection_item(username, collection_name, body, token):
     except schema.ValidationException as e:
         return {"statusCode": 400, "body": json.dumps({"message": "Invalid post schema", "error": str(e)})}
 
-    api_name = body["api_name"]
-    api_id = body["api_id"]
-    item_id = None
-
+    item_id = body["id"]
     try:
         if collection_name == "anime":
-            item_id = anime_api.post_anime(api_name, api_id, token)
+            anime_api.get_anime(item_id, token)
         elif collection_name == "show":
-            item_id = shows_api.post_show(api_name, api_id, token)
+            shows_api.get_show(item_id, token)
         elif collection_name == "movie":
             return {"statusCode": 501}  # TODO: Implement
     except api_errors.HttpError as e:
-        err_msg = f"Could not post {collection_name}"
+        err_msg = f"Could not get {collection_name}"
         log.error(f"{err_msg}. Error: {str(e)}")
         return {"statusCode": e.status_code, "body": json.dumps({"message": err_msg}), "error": str(e)}
 

--- a/src/lambdas/api/watch_history_by_collection/__init__.py
+++ b/src/lambdas/api/watch_history_by_collection/__init__.py
@@ -67,14 +67,6 @@ def _get_watch_history(username, collection_name, query_params, token):
     try:
         watch_history = watch_history_db.get_watch_history(username, collection_name=collection_name, index_name=sort,
                                                            limit=limit, start=start)
-
-        # Fetch anime posters for all items in returned watch_history items
-        if collection_name == "anime":
-            anime = anime_api.get_animes(watch_history["items"].keys(), token)
-
-            for anime_id in anime:
-                watch_history["items"][anime_id].update(anime[anime_id])
-
         return {"statusCode": 200, "body": json.dumps(watch_history, cls=decimal_encoder.DecimalEncoder)}
     except watch_history_db.NotFoundError:
         return {"statusCode": 200, "body": json.dumps({"items": []})}

--- a/src/lambdas/api/watch_history_by_collection/post.json
+++ b/src/lambdas/api/watch_history_by_collection/post.json
@@ -6,16 +6,23 @@
   "default": {},
   "examples": [
     {
-      "item_add_id": 123
+      "api_name": "mal",
+      "api_id": 123
     }
   ],
   "additionalProperties": false,
   "properties": {
-    "item_add_id": {
-      "$id": "#/properties/item_add_id",
+    "api_name": {
+      "$id": "#/properties/api_name",
+      "type": "string",
+      "title": "API name",
+      "description": "One of the predefined enum string values defining third party API"
+    },
+    "api_id": {
+      "$id": "#/properties/api_id",
       "type": "integer",
-      "title": "Item add ID",
-      "description": "Item ID to use for the add operation"
+      "title": "API Item ID",
+      "description": "The external ID of the item inside the third party API"
     }
   }
 }

--- a/src/lambdas/api/watch_history_by_collection/post.json
+++ b/src/lambdas/api/watch_history_by_collection/post.json
@@ -6,23 +6,16 @@
   "default": {},
   "examples": [
     {
-      "api_name": "mal",
-      "api_id": 123
+      "id": "b24ed2d5-8e77-4fe0-b5a1-d0e68cf4d9c5"
     }
   ],
   "additionalProperties": false,
   "properties": {
-    "api_name": {
-      "$id": "#/properties/api_name",
+    "id": {
+      "$id": "#/properties/id",
       "type": "string",
-      "title": "API name",
-      "description": "One of the predefined enum string values defining third party API"
-    },
-    "api_id": {
-      "$id": "#/properties/api_id",
-      "type": "integer",
-      "title": "API Item ID",
-      "description": "The external ID of the item inside the third party API"
+      "title": "Item UUID",
+      "description": "The UUID for the collection item"
     }
   }
 }

--- a/src/layers/api/python/anime_api.py
+++ b/src/layers/api/python/anime_api.py
@@ -6,12 +6,12 @@ import api_errors
 ANIME_API_URL = os.getenv("ANIME_API_URL")
 
 
-def post_anime(api_name, api_id, token):
-    res = requests.post(f"{ANIME_API_URL}/anime?{api_name}_id={api_id}", headers={"Authorization": token})
-    if res.status_code != 202:
-        raise api_errors.HttpError("Invalid response in post_anime", res.status_code)
+def get_anime(anime_id, token):
+    res = requests.get(f"{ANIME_API_URL}/anime/{anime_id}", headers={"Authorization": token})
+    if res.status_code != 200:
+        raise api_errors.HttpError("Invalid response in get_anime", res.status_code)
 
-    return res.json()["anime_id"]
+    return res.json()
 
 
 def get_animes(ids, token):

--- a/src/layers/api/python/anime_api.py
+++ b/src/layers/api/python/anime_api.py
@@ -9,7 +9,7 @@ ANIME_API_URL = os.getenv("ANIME_API_URL")
 def post_anime(api_name, api_id, token):
     res = requests.post(f"{ANIME_API_URL}/anime?{api_name}_id={api_id}", headers={"Authorization": token})
     if res.status_code != 202:
-        raise api_errors.HttpError(f"Invalid response: {res.status_code}")
+        raise api_errors.HttpError("Invalid response in post_anime", res.status_code)
 
     return res.json()["anime_id"]
 
@@ -18,6 +18,6 @@ def get_animes(ids, token):
     ids = ",".join(ids)
     res = requests.get(f"{ANIME_API_URL}/animes/{ids}", headers={"Authorization": token})
     if res.status_code != 200:
-        raise api_errors.HttpError(f"Invalid response: {res.status_code}")
+        raise api_errors.HttpError("Invalid response in get_animes", res.status_code)
 
     return res.json()

--- a/src/layers/api/python/anime_api.py
+++ b/src/layers/api/python/anime_api.py
@@ -12,12 +12,3 @@ def get_anime(anime_id, token):
         raise api_errors.HttpError("Invalid response in get_anime", res.status_code)
 
     return res.json()
-
-
-def get_animes(ids, token):
-    ids = ",".join(ids)
-    res = requests.get(f"{ANIME_API_URL}/animes/{ids}", headers={"Authorization": token})
-    if res.status_code != 200:
-        raise api_errors.HttpError("Invalid response in get_animes", res.status_code)
-
-    return res.json()

--- a/src/layers/api/python/anime_api.py
+++ b/src/layers/api/python/anime_api.py
@@ -1,22 +1,15 @@
 import os
-
 import requests
+
+import api_errors
 
 ANIME_API_URL = os.getenv("ANIME_API_URL")
 
 
-class Error(Exception):
-    pass
-
-
-class HttpError(Error):
-    pass
-
-
-def post_anime(mal_id, token):
-    res = requests.post(f"{ANIME_API_URL}/anime?mal_id={mal_id}", headers={"Authorization": token})
+def post_anime(api_name, api_id, token):
+    res = requests.post(f"{ANIME_API_URL}/anime?{api_name}_id={api_id}", headers={"Authorization": token})
     if res.status_code != 202:
-        raise HttpError(f"Invalid response: {res.status_code}")
+        raise api_errors.HttpError(f"Invalid response: {res.status_code}")
 
     return res.json()["anime_id"]
 
@@ -25,6 +18,6 @@ def get_animes(ids, token):
     ids = ",".join(ids)
     res = requests.get(f"{ANIME_API_URL}/animes/{ids}", headers={"Authorization": token})
     if res.status_code != 200:
-        raise HttpError(f"Invalid response: {res.status_code}")
+        raise api_errors.HttpError(f"Invalid response: {res.status_code}")
 
     return res.json()

--- a/src/layers/api/python/api_errors.py
+++ b/src/layers/api/python/api_errors.py
@@ -1,0 +1,6 @@
+class Error(Exception):
+    pass
+
+
+class HttpError(Error):
+    pass

--- a/src/layers/api/python/api_errors.py
+++ b/src/layers/api/python/api_errors.py
@@ -3,4 +3,7 @@ class Error(Exception):
 
 
 class HttpError(Error):
-    pass
+
+    def __init__(self, message, status_code):
+        super(HttpError, self).__init__(message)
+        self.status_code = status_code

--- a/src/layers/api/python/shows_api.py
+++ b/src/layers/api/python/shows_api.py
@@ -9,6 +9,6 @@ SHOWS_API_URL = os.getenv("SHOWS_API_URL")
 def post_show(api_name, api_id, token):
     res = requests.post(f"{SHOWS_API_URL}/show?{api_name}_id={api_id}", headers={"Authorization": token})
     if res.status_code != 202:
-        raise api_errors.HttpError(f"Invalid response: {res.status_code}")
+        raise api_errors.HttpError("Invalid response in post_show", res.status_code)
 
     return res.json()["show_id"]

--- a/src/layers/api/python/shows_api.py
+++ b/src/layers/api/python/shows_api.py
@@ -6,9 +6,9 @@ import api_errors
 SHOWS_API_URL = os.getenv("SHOWS_API_URL")
 
 
-def post_show(api_name, api_id, token):
-    res = requests.post(f"{SHOWS_API_URL}/show?{api_name}_id={api_id}", headers={"Authorization": token})
-    if res.status_code != 202:
-        raise api_errors.HttpError("Invalid response in post_show", res.status_code)
+def get_show(show_id, token):
+    res = requests.get(f"{SHOWS_API_URL}/show/{show_id}", headers={"Authorization": token})
+    if res.status_code != 200:
+        raise api_errors.HttpError("Invalid response in get_show", res.status_code)
 
-    return res.json()["show_id"]
+    return res.json()

--- a/src/layers/api/python/shows_api.py
+++ b/src/layers/api/python/shows_api.py
@@ -1,0 +1,14 @@
+import os
+import requests
+
+import api_errors
+
+SHOWS_API_URL = os.getenv("SHOWS_API_URL")
+
+
+def post_show(api_name, api_id, token):
+    res = requests.post(f"{SHOWS_API_URL}/show?{api_name}_id={api_id}", headers={"Authorization": token})
+    if res.status_code != 202:
+        raise api_errors.HttpError(f"Invalid response: {res.status_code}")
+
+    return res.json()["show_id"]

--- a/src/layers/databases/python/watch_history_db.py
+++ b/src/layers/databases/python/watch_history_db.py
@@ -152,9 +152,8 @@ def _watch_history_generator(username, limit, collection_name=None, index_name=N
     page_iterator = paginator.paginate(**query_kwargs)
 
     for p in page_iterator:
-        items = {}
+        items = []
         for i in p["Items"]:
             item = json_util.loads(i)
-            item_id = item.pop("item_id")
-            items[item_id] = item
+            items.append(item)
         yield items

--- a/test/apitest/test_episodes.py
+++ b/test/apitest/test_episodes.py
@@ -22,7 +22,7 @@ def test_get_episodes_invalid_collection_item():
 
 def test_get_episodes():
     # Setup
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"id": "23d5d8c1-2ab0-5279-a501-4d248dc9a63c"}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
     res = requests.post(f"{API_URL}/watch-history/collection/anime/23d5d8c1-2ab0-5279-a501-4d248dc9a63c/episode", json={"episode_id": "10"}, headers=BASE_HEADERS)

--- a/test/apitest/test_episodes.py
+++ b/test/apitest/test_episodes.py
@@ -22,7 +22,7 @@ def test_get_episodes_invalid_collection_item():
 
 def test_get_episodes():
     # Setup
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"item_add_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
     res = requests.post(f"{API_URL}/watch-history/collection/anime/23d5d8c1-2ab0-5279-a501-4d248dc9a63c/episode", json={"episode_id": "10"}, headers=BASE_HEADERS)

--- a/test/apitest/test_watch_history.py
+++ b/test/apitest/test_watch_history.py
@@ -22,10 +22,10 @@ def test_get_watch_history_invalid_collection_item():
 
 def test_get_watch_history():
     # Setup
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"item_add_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"item_add_id": 21}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 21}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
 
@@ -56,14 +56,14 @@ def test_get_watch_history():
 
 
 def test_post_anime_item():
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"item_add_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
 
     assert res.status_code == 204
     time.sleep(1)
 
 
 def test_delete_anime_item():
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"item_add_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
 
@@ -79,7 +79,7 @@ def test_delete_anime_item():
 
 
 def test_get_anime_item():
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"item_add_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
 
@@ -96,7 +96,7 @@ def test_get_anime_item():
 
 
 def test_patch_anime_item():
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"item_add_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
 

--- a/test/apitest/test_watch_history.py
+++ b/test/apitest/test_watch_history.py
@@ -22,10 +22,10 @@ def test_get_watch_history_invalid_collection_item():
 
 def test_get_watch_history():
     # Setup
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"id": "23d5d8c1-2ab0-5279-a501-4d248dc9a63c"}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 21}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": "0877ed59-6198-5cf4-a254-91564808db3e"}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
 
@@ -56,14 +56,14 @@ def test_get_watch_history():
 
 
 def test_post_anime_item():
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"id": "23d5d8c1-2ab0-5279-a501-4d248dc9a63c"}, headers=BASE_HEADERS)
 
     assert res.status_code == 204
     time.sleep(1)
 
 
 def test_delete_anime_item():
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"id": "23d5d8c1-2ab0-5279-a501-4d248dc9a63c"}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
 
@@ -79,7 +79,7 @@ def test_delete_anime_item():
 
 
 def test_get_anime_item():
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"id": "23d5d8c1-2ab0-5279-a501-4d248dc9a63c"}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
 
@@ -96,7 +96,7 @@ def test_get_anime_item():
 
 
 def test_patch_anime_item():
-    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"api_id": 20}, headers=BASE_HEADERS)
+    res = requests.post(f"{API_URL}/watch-history/collection/anime", json={"id": "23d5d8c1-2ab0-5279-a501-4d248dc9a63c"}, headers=BASE_HEADERS)
     assert res.status_code == 204
     time.sleep(1)
 

--- a/test/unittest/conftest.py
+++ b/test/unittest/conftest.py
@@ -33,3 +33,12 @@ def mocked_episodes_db():
     episodes_db.client = MagicMock()
 
     return episodes_db
+
+
+@pytest.fixture(scope='function')
+def mocked_show_api():
+    import shows_api
+
+    shows_api.SHOW_API_URL = "https://mocked"
+
+    return shows_api

--- a/test/unittest/test_anime_api.py
+++ b/test/unittest/test_anime_api.py
@@ -25,25 +25,3 @@ def test_post_anime_invalid_code(mocked_get, mocked_anime_api):
 
     with pytest.raises(api_errors.HttpError):
         mocked_anime_api.get_anime("123", "TEST_TOKEN")
-
-
-@patch("anime_api.requests.get")
-def test_get_animes(mocked_get, mocked_anime_api):
-    m = MagicMock()
-    m.status_code = 200
-    m.json.return_value = {"anime_id": "123"}
-    mocked_get.return_value = m
-
-    ret = mocked_anime_api.get_animes("123,456", "TEST_TOKEN")
-
-    assert ret == {'anime_id': '123'}
-
-
-@patch("anime_api.requests.get")
-def test_get_animes_invalid_code(mocked_get, mocked_anime_api):
-    m = MagicMock()
-    m.status_code = 404
-    mocked_get.return_value = m
-
-    with pytest.raises(api_errors.HttpError):
-        mocked_anime_api.get_animes("123", "TEST_TOKEN")

--- a/test/unittest/test_anime_api.py
+++ b/test/unittest/test_anime_api.py
@@ -5,26 +5,26 @@ import pytest
 import api_errors
 
 
-@patch("anime_api.requests.post")
-def test_post_anime(mocked_post, mocked_anime_api):
+@patch("anime_api.requests.get")
+def test_get_anime(mocked_get, mocked_anime_api):
     m = MagicMock()
-    m.status_code = 202
+    m.status_code = 200
     m.json.return_value = {"anime_id": "123"}
-    mocked_post.return_value = m
+    mocked_get.return_value = m
 
-    ret = mocked_anime_api.post_anime("mal", "123", "TEST_TOKEN")
+    ret = mocked_anime_api.get_anime("123", "TEST_TOKEN")
 
-    assert ret == "123"
+    assert ret == {"anime_id": "123"}
 
 
-@patch("anime_api.requests.post")
-def test_post_anime_invalid_code(mocked_post, mocked_anime_api):
+@patch("anime_api.requests.get")
+def test_post_anime_invalid_code(mocked_get, mocked_anime_api):
     m = MagicMock()
     m.status_code = 404
-    mocked_post.return_value = m
+    mocked_get.return_value = m
 
     with pytest.raises(api_errors.HttpError):
-        mocked_anime_api.post_anime("mal", "123", "TEST_TOKEN")
+        mocked_anime_api.get_anime("123", "TEST_TOKEN")
 
 
 @patch("anime_api.requests.get")

--- a/test/unittest/test_anime_api.py
+++ b/test/unittest/test_anime_api.py
@@ -2,6 +2,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+import api_errors
+
 
 @patch("anime_api.requests.post")
 def test_post_anime(mocked_post, mocked_anime_api):
@@ -10,7 +12,7 @@ def test_post_anime(mocked_post, mocked_anime_api):
     m.json.return_value = {"anime_id": "123"}
     mocked_post.return_value = m
 
-    ret = mocked_anime_api.post_anime("123", "TEST_TOKEN")
+    ret = mocked_anime_api.post_anime("mal", "123", "TEST_TOKEN")
 
     assert ret == "123"
 
@@ -21,8 +23,8 @@ def test_post_anime_invalid_code(mocked_post, mocked_anime_api):
     m.status_code = 404
     mocked_post.return_value = m
 
-    with pytest.raises(mocked_anime_api.HttpError):
-        mocked_anime_api.post_anime("123", "TEST_TOKEN")
+    with pytest.raises(api_errors.HttpError):
+        mocked_anime_api.post_anime("mal", "123", "TEST_TOKEN")
 
 
 @patch("anime_api.requests.get")
@@ -43,5 +45,5 @@ def test_get_animes_invalid_code(mocked_get, mocked_anime_api):
     m.status_code = 404
     mocked_get.return_value = m
 
-    with pytest.raises(mocked_anime_api.HttpError):
+    with pytest.raises(api_errors.HttpError):
         mocked_anime_api.get_animes("123", "TEST_TOKEN")

--- a/test/unittest/test_episode_by_collection.py
+++ b/test/unittest/test_episode_by_collection.py
@@ -2,9 +2,7 @@ import json
 from decimal import Decimal
 from unittest.mock import patch
 
-from anime_api import HttpError
 from api.episode_by_collection_item import handle
-from schema import ALLOWED_SORT
 from episodes_db import NotFoundError
 
 TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VybmFtZSI6IlRFU1RfQ0xJRU5UX0lEIn0.ud_dRdguJwmKv4XO-c4JD-dKGffSvXsxuAxZq9uWV-g"

--- a/test/unittest/test_show_api.py
+++ b/test/unittest/test_show_api.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import api_errors
+
+
+@patch("shows_api.requests.get")
+def test_get_show(mocked_get, mocked_show_api):
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = {"show_id": "123"}
+    mocked_get.return_value = m
+
+    ret = mocked_show_api.get_show("123", "TEST_TOKEN")
+
+    assert ret == {"show_id": "123"}
+
+
+@patch("shows_api.requests.get")
+def test_post_anime_invalid_code(mocked_get, mocked_show_api):
+    m = MagicMock()
+    m.status_code = 404
+    mocked_get.return_value = m
+
+    with pytest.raises(api_errors.HttpError):
+        mocked_show_api.get_show("123", "TEST_TOKEN")
+

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -267,7 +267,7 @@ def test_handler_post(mocked_post_anime, mocked_post):
 @patch("api.watch_history_by_collection.watch_history_db.update_item")
 @patch("api.watch_history_by_collection.anime_api.post_anime")
 def test_handler_post_anime_api_error(mocked_post_anime, mocked_post):
-    mocked_post_anime.side_effect = HttpError
+    mocked_post_anime.side_effect = HttpError("test_error", 403)
     mocked_post.return_value = True
 
     event = {
@@ -288,8 +288,9 @@ def test_handler_post_anime_api_error(mocked_post_anime, mocked_post):
 
     ret = handle(event, None)
     assert ret == {
-        'body': '{"message": "Error during anime post", "error": ""}',
-        'statusCode': 503
+        'body': '{"message": "Could not post anime"}',
+        'error': 'test_error',
+        'statusCode': 403
     }
 
 

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -239,9 +239,9 @@ def test_handler_post_with_empty_body(mocked_post):
 
 
 @patch("api.watch_history_by_collection.watch_history_db.add_item")
-@patch("api.watch_history_by_collection.anime_api.post_anime")
-def test_handler_post(mocked_post_anime, mocked_post):
-    mocked_post_anime.return_value = True
+@patch("api.watch_history_by_collection.anime_api.get_anime")
+def test_handler_post(mocked_get_anime, mocked_post):
+    mocked_get_anime.return_value = True
     mocked_post.return_value = True
 
     event = {
@@ -257,7 +257,7 @@ def test_handler_post(mocked_post_anime, mocked_post):
             "collection_name": "anime",
             "item_id": "123"
         },
-        "body": '{ "api_name": "mal", "api_id": 123 }'
+        "body": '{ "id": "123" }'
     }
 
     ret = handle(event, None)
@@ -265,9 +265,9 @@ def test_handler_post(mocked_post_anime, mocked_post):
 
 
 @patch("api.watch_history_by_collection.watch_history_db.update_item")
-@patch("api.watch_history_by_collection.anime_api.post_anime")
-def test_handler_post_anime_api_error(mocked_post_anime, mocked_post):
-    mocked_post_anime.side_effect = HttpError("test_error", 403)
+@patch("api.watch_history_by_collection.anime_api.get_anime")
+def test_handler_get_anime_api_error(mocked_get_anime, mocked_post):
+    mocked_get_anime.side_effect = HttpError("test_error", 403)
     mocked_post.return_value = True
 
     event = {
@@ -283,12 +283,12 @@ def test_handler_post_anime_api_error(mocked_post_anime, mocked_post):
             "collection_name": "anime",
             "item_id": "123"
         },
-        "body": '{ "api_name": "mal", "api_id": 123 }'
+        "body": '{ "id": "123" }'
     }
 
     ret = handle(event, None)
     assert ret == {
-        'body': '{"message": "Could not post anime"}',
+        'body': '{"message": "Could not get anime"}',
         'error': 'test_error',
         'statusCode': 403
     }

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -232,7 +232,7 @@ def test_handler_post_with_empty_body(mocked_post):
 
 @patch("api.watch_history_by_collection.watch_history_db.add_item")
 @patch("api.watch_history_by_collection.anime_api.get_anime")
-def test_handler_post(mocked_get_anime, mocked_post):
+def test_handler_post_anime(mocked_get_anime, mocked_post):
     mocked_get_anime.return_value = True
     mocked_post.return_value = True
 
@@ -254,6 +254,56 @@ def test_handler_post(mocked_get_anime, mocked_post):
 
     ret = handle(event, None)
     assert ret == {'statusCode': 204}
+
+@patch("api.watch_history_by_collection.watch_history_db.add_item")
+@patch("api.watch_history_by_collection.shows_api.get_show")
+def test_handler_post_show(mocked_get_show, mocked_post):
+    mocked_get_show.return_value = True
+    mocked_post.return_value = True
+
+    event = {
+        "headers": {
+            "authorization": TEST_JWT
+        },
+        "requestContext": {
+            "http": {
+                "method": "POST"
+            }
+        },
+        "pathParameters": {
+            "collection_name": "show",
+            "item_id": "123"
+        },
+        "body": '{ "id": "123" }'
+    }
+
+    ret = handle(event, None)
+    assert ret == {'statusCode': 204}
+
+@patch("api.watch_history_by_collection.watch_history_db.add_item")
+@patch("api.watch_history_by_collection.shows_api.get_show")
+def test_handler_post_movie(mocked_get_show, mocked_post):
+    mocked_get_show.return_value = True
+    mocked_post.return_value = True
+
+    event = {
+        "headers": {
+            "authorization": TEST_JWT
+        },
+        "requestContext": {
+            "http": {
+                "method": "POST"
+            }
+        },
+        "pathParameters": {
+            "collection_name": "movie",
+            "item_id": "123"
+        },
+        "body": '{ "id": "123" }'
+    }
+
+    ret = handle(event, None)
+    assert ret == {'statusCode': 501}
 
 
 @patch("api.watch_history_by_collection.watch_history_db.update_item")

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -35,6 +35,7 @@ def test_handler(mocked_get_watch_history):
         "statusCode": 200
     }
 
+
 def test_handler_invalid_sort():
     event = {
         "headers": {
@@ -255,6 +256,7 @@ def test_handler_post_anime(mocked_get_anime, mocked_post):
     ret = handle(event, None)
     assert ret == {'statusCode': 204}
 
+
 @patch("api.watch_history_by_collection.watch_history_db.add_item")
 @patch("api.watch_history_by_collection.shows_api.get_show")
 def test_handler_post_show(mocked_get_show, mocked_post):
@@ -279,6 +281,7 @@ def test_handler_post_show(mocked_get_show, mocked_post):
 
     ret = handle(event, None)
     assert ret == {'statusCode': 204}
+
 
 @patch("api.watch_history_by_collection.watch_history_db.add_item")
 @patch("api.watch_history_by_collection.shows_api.get_show")

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -11,17 +11,10 @@ TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VybmFtZSI6IlRFU
 
 
 @patch("api.watch_history_by_collection.watch_history_db.get_watch_history")
-@patch("api.watch_history_by_collection.anime_api.get_animes")
-def test_handler_anime(mocked_get_animes, mocked_get_watch_history):
+def test_handler(mocked_get_watch_history):
     mocked_get_watch_history.return_value = {
         "items": {"123": {"collection_name": "anime", "item_id": Decimal(123)}}
     }
-    mocked_get_animes.return_value = {
-        "123": {
-            "title": "anime_title"
-        }
-    }
-
     event = {
         "headers": {
             "authorization": TEST_JWT
@@ -38,43 +31,9 @@ def test_handler_anime(mocked_get_animes, mocked_get_watch_history):
 
     ret = handle(event, None)
     assert ret == {
-        'body': '{"items": {"123": {"collection_name": "anime", "item_id": 123, "title": "anime_title"}}}',
+        'body': '{"items": {"123": {"collection_name": "anime", "item_id": 123}}}',
         "statusCode": 200
     }
-
-
-@patch("api.watch_history_by_collection.watch_history_db.get_watch_history")
-@patch("api.watch_history_by_collection.show_api.get_show")
-def test_handler_show(mocked_get_show, mocked_get_watch_history):
-    mocked_get_watch_history.return_value = {
-        "items": {"123": {"collection_name": "anime", "item_id": Decimal(123)}}
-    }
-    mocked_get_show.return_value = {
-        "123": {
-            "title": "show_title"
-        }
-    }
-
-    event = {
-        "headers": {
-            "authorization": TEST_JWT
-        },
-        "pathParameters": {
-            "collection_name": "show"
-        },
-        "requestContext": {
-            "http": {
-                "method": "GET"
-            }
-        }
-    }
-
-    ret = handle(event, None)
-    assert ret == {
-        'body': '{"items": {"123": {"collection_name": "show", "item_id": 123, "title": "show_title"}}}',
-        "statusCode": 200
-    }
-
 
 def test_handler_invalid_sort():
     event = {

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -12,7 +12,7 @@ TEST_JWT = "eyJraWQiOiIxMjMxMjMxMjM9IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VybmFtZSI6IlRFU
 
 @patch("api.watch_history_by_collection.watch_history_db.get_watch_history")
 @patch("api.watch_history_by_collection.anime_api.get_animes")
-def test_handler(mocked_get_animes, mocked_get_watch_history):
+def test_handler_anime(mocked_get_animes, mocked_get_watch_history):
     mocked_get_watch_history.return_value = {
         "items": {"123": {"collection_name": "anime", "item_id": Decimal(123)}}
     }
@@ -39,6 +39,39 @@ def test_handler(mocked_get_animes, mocked_get_watch_history):
     ret = handle(event, None)
     assert ret == {
         'body': '{"items": {"123": {"collection_name": "anime", "item_id": 123, "title": "anime_title"}}}',
+        "statusCode": 200
+    }
+
+
+@patch("api.watch_history_by_collection.watch_history_db.get_watch_history")
+@patch("api.watch_history_by_collection.show_api.get_show")
+def test_handler_show(mocked_get_show, mocked_get_watch_history):
+    mocked_get_watch_history.return_value = {
+        "items": {"123": {"collection_name": "anime", "item_id": Decimal(123)}}
+    }
+    mocked_get_show.return_value = {
+        "123": {
+            "title": "show_title"
+        }
+    }
+
+    event = {
+        "headers": {
+            "authorization": TEST_JWT
+        },
+        "pathParameters": {
+            "collection_name": "show"
+        },
+        "requestContext": {
+            "http": {
+                "method": "GET"
+            }
+        }
+    }
+
+    ret = handle(event, None)
+    assert ret == {
+        'body': '{"items": {"123": {"collection_name": "show", "item_id": 123, "title": "show_title"}}}',
         "statusCode": 200
     }
 

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -2,7 +2,7 @@ import json
 from decimal import Decimal
 from unittest.mock import patch
 
-from anime_api import HttpError
+from api_errors import HttpError
 from api.watch_history_by_collection import handle
 from schema import ALLOWED_SORT
 from watch_history_db import NotFoundError
@@ -257,7 +257,7 @@ def test_handler_post(mocked_post_anime, mocked_post):
             "collection_name": "anime",
             "item_id": "123"
         },
-        "body": '{ "item_add_id": 123 }'
+        "body": '{ "api_name": "mal", "api_id": 123 }'
     }
 
     ret = handle(event, None)
@@ -283,7 +283,7 @@ def test_handler_post_anime_api_error(mocked_post_anime, mocked_post):
             "collection_name": "anime",
             "item_id": "123"
         },
-        "body": '{ "item_add_id": 123 }'
+        "body": '{ "api_name": "mal", "api_id": 123 }'
     }
 
     ret = handle(event, None)
@@ -310,7 +310,7 @@ def test_handler_post_invalid_collection(mocked_post):
             "collection_name": "INVALID",
             "item_id": "123"
         },
-        "body": '{ "item_add_id": 123 }'
+        "body": '{ "api_id": 123 }'
     }
 
     ret = handle(event, None)

--- a/test/unittest/test_watch_history_db.py
+++ b/test/unittest/test_watch_history_db.py
@@ -137,7 +137,7 @@ def test_get_watch_history_by_with_start(mocked_watch_history_db):
         "TableName": None
     }
     assert ret == {
-        'items': {123: {'collection_name': 'MOVIE'}},
+        'items': [{"item_id": 123, 'collection_name': 'MOVIE'}],
         "total_pages": 2
     }
 


### PR DESCRIPTION
* Don't post items from watch-history post. Post them from clients and just check if items exist in the correct collection
* Implement post show item support
* Don't send `GET /v1/animes/{ids}` to anime service while gettin watch history for a given collection. Let clients handle this (or none/other requests when needed)
* `GET /v1/watch-history/{collection}` returns a simple list of items instead of a map mapping key to item data