### PR TITLE
Fix watch date item/episode issues

### DIFF
--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -52,8 +52,8 @@ class WatchHistory(core.Stack):
             index_name="rating"
         )
         self.watch_history_table.add_local_secondary_index(
-            sort_key=Attribute(name="date_watched", type=AttributeType.STRING),
-            index_name="date_watched"
+            sort_key=Attribute(name="dates_watched", type=AttributeType.STRING),
+            index_name="dates_watched"
         )
         self.watch_history_table.add_local_secondary_index(
             sort_key=Attribute(name="state", type=AttributeType.STRING),

--- a/deploy/lib/watch_history.py
+++ b/deploy/lib/watch_history.py
@@ -52,8 +52,8 @@ class WatchHistory(core.Stack):
             index_name="rating"
         )
         self.watch_history_table.add_local_secondary_index(
-            sort_key=Attribute(name="dates_watched", type=AttributeType.STRING),
-            index_name="dates_watched"
+            sort_key=Attribute(name="latest_watch_date", type=AttributeType.STRING),
+            index_name="latest_watch_date"
         )
         self.watch_history_table.add_local_secondary_index(
             sort_key=Attribute(name="state", type=AttributeType.STRING),
@@ -66,6 +66,10 @@ class WatchHistory(core.Stack):
             partition_key=Attribute(name="username", type=AttributeType.STRING),
             sort_key=Attribute(name="id", type=AttributeType.STRING),
             billing_mode=BillingMode.PAY_PER_REQUEST,
+        )
+        self.episodes_table.add_local_secondary_index(
+            sort_key=Attribute(name="latest_watch_date", type=AttributeType.STRING),
+            index_name="latest_watch_date"
         )
 
     def _create_lambdas_config(self):

--- a/src/lambdas/api/episode_by_id/patch.json
+++ b/src/lambdas/api/episode_by_id/patch.json
@@ -7,7 +7,7 @@
   "examples": [
     {
       "rating": 3,
-      "overview": "My ovweview text",
+      "overview": "My overview text",
       "review": "Very long review about the episode",
       "dates_watched": [
         "2020-01-01 10:00:00",

--- a/src/lambdas/api/episode_by_id/patch.json
+++ b/src/lambdas/api/episode_by_id/patch.json
@@ -9,7 +9,7 @@
       "rating": 3,
       "overview": "My ovweview text",
       "review": "Very long review about the episode",
-      "date_watched": [
+      "dates_watched": [
         "2020-01-01 10:00:00",
         "2020-01-02 11:00:00"
       ]

--- a/src/lambdas/api/item_by_collection/patch.json
+++ b/src/lambdas/api/item_by_collection/patch.json
@@ -9,7 +9,7 @@
       "rating": 3,
       "overview": "My overview text",
       "review": "Very long review about the item",
-      "date_watched": [
+      "dates_watched": [
         "2020-01-01 10:00:00",
         "2020-01-02 11:00:00"
       ],
@@ -40,7 +40,7 @@
       "description": "Review for the item",
       "maxLength": 80000
     },
-    "date_watched": {
+    "dates_watched": {
       "$id": "#/properties/name",
       "type": "array",
       "title": "Watch date(s)",

--- a/src/lambdas/api/watch_history/__init__.py
+++ b/src/lambdas/api/watch_history/__init__.py
@@ -7,7 +7,7 @@ import watch_history_db
 
 log = logger.get_logger("watch_history")
 
-ALLOWED_SORT = ["rating", "date_watched", "state"]
+ALLOWED_SORT = ["rating", "dates_watched", "state"]
 
 
 def handle(event, context):

--- a/src/layers/databases/python/episodes_db.py
+++ b/src/layers/databases/python/episodes_db.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 
 import boto3
+import dateutil.parser
 from boto3.dynamodb.conditions import Key, Attr
 from dynamodb_json import json_util
 
@@ -74,6 +75,14 @@ def get_episode(username, collection_name, episode_id):
 def update_episode(username, collection_name, episode_id, data):
     data["collection_name"] = collection_name
     data["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    if "dates_watched" in data:
+        data["latest_watch_date"] = data["dates_watched"][0]
+
+        for watch_date in data["dates_watched"]:
+            next_date = dateutil.parser.parse(watch_date)
+            if next_date > data["latest_watch_date"]:
+                data["latest_watch_date"] = next_date
 
     items = ','.join(f'#{k}=:{k}' for k in data)
     update_expression = f"SET {items}"

--- a/src/layers/databases/python/episodes_db.py
+++ b/src/layers/databases/python/episodes_db.py
@@ -77,12 +77,13 @@ def update_episode(username, collection_name, episode_id, data):
     data["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     if "dates_watched" in data:
-        data["latest_watch_date"] = data["dates_watched"][0]
+        latest_date = dateutil.parser.parse(data["dates_watched"][0])
 
         for watch_date in data["dates_watched"]:
             next_date = dateutil.parser.parse(watch_date)
-            if next_date > data["latest_watch_date"]:
-                data["latest_watch_date"] = next_date
+            if next_date > latest_date:
+                latest_date = next_date
+                data["latest_watch_date"] = watch_date
 
     items = ','.join(f'#{k}=:{k}' for k in data)
     update_expression = f"SET {items}"

--- a/src/layers/databases/python/watch_history_db.py
+++ b/src/layers/databases/python/watch_history_db.py
@@ -75,12 +75,13 @@ def update_item(username, collection_name, item_id, data):
     data["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     if "dates_watched" in data:
-        data["latest_watch_date"] = data["dates_watched"][0]
+        latest_date = dateutil.parser.parse(data["dates_watched"][0])
 
         for watch_date in data["dates_watched"]:
             next_date = dateutil.parser.parse(watch_date)
-            if next_date > data["latest_watch_date"]:
-                data["latest_watch_date"] = next_date
+            if next_date > latest_date:
+                latest_date = next_date
+                data["latest_watch_date"] = watch_date
 
     items = ','.join(f'#{k}=:{k}' for k in data)
     update_expression = f"SET {items}"

--- a/src/layers/databases/python/watch_history_db.py
+++ b/src/layers/databases/python/watch_history_db.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 
 import boto3
+import dateutil.parser
 from boto3.dynamodb.conditions import Key, Attr
 from dynamodb_json import json_util
 
@@ -72,6 +73,14 @@ def get_item(username, collection_name, item_id):
 def update_item(username, collection_name, item_id, data):
     data["collection_name"] = collection_name
     data["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    if "dates_watched" in data:
+        data["latest_watch_date"] = data["dates_watched"][0]
+
+        for watch_date in data["dates_watched"]:
+            next_date = dateutil.parser.parse(watch_date)
+            if next_date > data["latest_watch_date"]:
+                data["latest_watch_date"] = next_date
 
     items = ','.join(f'#{k}=:{k}' for k in data)
     update_expression = f"SET {items}"

--- a/src/layers/databases/requirements.in
+++ b/src/layers/databases/requirements.in
@@ -1,1 +1,2 @@
 dynamodb_json
+python-dateutil

--- a/src/layers/databases/requirements.txt
+++ b/src/layers/databases/requirements.txt
@@ -23,7 +23,7 @@ jmespath==0.10.0 \
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
     --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a \
-    # via botocore
+    # via -r src/layers/databases/requirements.in, botocore
 s3transfer==0.3.3 \
     --hash=sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13 \
     --hash=sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db \

--- a/src/layers/utils/python/schema.py
+++ b/src/layers/utils/python/schema.py
@@ -6,7 +6,7 @@ import logger
 log = logger.get_logger(__name__)
 
 COLLECTION_NAMES = ["anime", "show", "movie"]
-ALLOWED_SORT = ["rating", "date_watched", "state"]
+ALLOWED_SORT = ["rating", "dates_watched", "state"]
 
 
 class ValidationException(Exception):

--- a/test/unittest/test_episodes_db.py
+++ b/test/unittest/test_episodes_db.py
@@ -206,7 +206,38 @@ def test_update_episode(mocked_episodes_db):
         'Key': {
             'username': TEST_USERNAME,
             'id': '123'},
-        'UpdateExpression': 'SET #overview=:overview,#collection_name=:collection_name,#updated_at=:updated_at REMOVE deleted_at'
+        'UpdateExpression': 'SET #overview=:overview,#collection_name=:collection_name,'
+                            '#updated_at=:updated_at REMOVE deleted_at'
+    }
+
+
+def test_update_episode_dates_watched(mocked_episodes_db):
+    global UPDATE_VALUES
+    UPDATE_VALUES = {}
+    mocked_episodes_db.table.update_item = mock_func
+
+    mocked_episodes_db.update_episode(TEST_USERNAME, "MOVIE", "123",
+                                      {"dates_watched": ["2020-12-20T15:30:09.909Z", "2021-12-20T15:30:09.909Z"]})
+
+    assert UPDATE_VALUES == {
+        'ExpressionAttributeNames': {
+            '#collection_name': 'collection_name',
+            '#updated_at': 'updated_at',
+            '#dates_watched': 'dates_watched',
+            '#latest_watch_date': 'latest_watch_date',
+        },
+        'ExpressionAttributeValues': {
+            ':collection_name': 'MOVIE',
+            ":updated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            ':dates_watched': ['2020-12-20T15:30:09.909Z',
+                               '2021-12-20T15:30:09.909Z'],
+            ':latest_watch_date': '2021-12-20T15:30:09.909Z',
+        },
+        'Key': {
+            'username': TEST_USERNAME,
+            'id': '123'},
+        'UpdateExpression': 'SET #dates_watched=:dates_watched,#collection_name=:collection_name,'
+                            '#updated_at=:updated_at,#latest_watch_date=:latest_watch_date REMOVE deleted_at'
     }
 
 

--- a/test/unittest/test_episodes_db.py
+++ b/test/unittest/test_episodes_db.py
@@ -190,23 +190,23 @@ def test_update_episode(mocked_episodes_db):
     UPDATE_VALUES = {}
     mocked_episodes_db.table.update_item = mock_func
 
-    mocked_episodes_db.add_episode(TEST_USERNAME, "MOVIE", "123", "123123")
+    mocked_episodes_db.update_episode(TEST_USERNAME, "MOVIE", "123", {"overview": "overview_text"})
 
     assert UPDATE_VALUES == {
         'ExpressionAttributeNames': {
             '#collection_name': 'collection_name',
             '#updated_at': 'updated_at',
-            '#item_id': 'item_id',
+            '#overview': 'overview',
         },
         'ExpressionAttributeValues': {
             ':collection_name': 'MOVIE',
-            ':item_id': "123",
+            ':overview': "overview_text",
             ":updated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         },
         'Key': {
             'username': TEST_USERNAME,
-            'id': '123123'},
-        'UpdateExpression': 'SET #item_id=:item_id,#collection_name=:collection_name,#updated_at=:updated_at REMOVE deleted_at'
+            'id': '123'},
+        'UpdateExpression': 'SET #overview=:overview,#collection_name=:collection_name,#updated_at=:updated_at REMOVE deleted_at'
     }
 
 

--- a/test/unittest/test_watch_history.py
+++ b/test/unittest/test_watch_history.py
@@ -49,7 +49,7 @@ def test_handler_sort(mocked_get_watch_history):
             "authorization": TEST_JWT
         },
         "queryStringParameters": {
-            "sort": "date_watched"
+            "sort": "dates_watched"
         }
     }
 

--- a/test/unittest/test_watch_history_by_collection.py
+++ b/test/unittest/test_watch_history_by_collection.py
@@ -71,7 +71,7 @@ def test_handler_sort(mocked_get_watch_history):
             "authorization": TEST_JWT
         },
         "queryStringParameters": {
-            "sort": "date_watched"
+            "sort": "dates_watched"
         },
         "pathParameters": {
             "collection_name": "test_collection"

--- a/test/unittest/test_watch_history_db.py
+++ b/test/unittest/test_watch_history_db.py
@@ -257,6 +257,35 @@ def test_update_item(mocked_watch_history_db):
     }
 
 
+def test_update_item_dates_watched(mocked_watch_history_db):
+    global UPDATE_VALUES
+    UPDATE_VALUES = {}
+    mocked_watch_history_db.table.update_item = mock_func
+
+    mocked_watch_history_db.update_item(TEST_USERNAME, "MOVIE", "123", {"dates_watched": ["2020-12-20T15:30:09.909Z", "2021-12-20T15:30:09.909Z"]})
+
+    assert UPDATE_VALUES == {
+        'ExpressionAttributeNames': {
+            '#collection_name': 'collection_name',
+            '#updated_at': 'updated_at',
+            '#dates_watched': 'dates_watched',
+            '#latest_watch_date': 'latest_watch_date',
+        },
+        'ExpressionAttributeValues': {
+            ':collection_name': 'MOVIE',
+            ":updated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            ':dates_watched': ['2020-12-20T15:30:09.909Z',
+                               '2021-12-20T15:30:09.909Z'],
+            ':latest_watch_date': '2021-12-20T15:30:09.909Z',
+        },
+        'Key': {
+            'username': TEST_USERNAME,
+            'item_id': '123'},
+        'UpdateExpression': 'SET #dates_watched=:dates_watched,#collection_name=:collection_name,'
+                            '#updated_at=:updated_at,#latest_watch_date=:latest_watch_date REMOVE deleted_at'
+    }
+
+
 def test_delete_item(mocked_watch_history_db):
     global UPDATE_VALUES
     UPDATE_VALUES = {}

--- a/test/unittest/test_watch_history_db.py
+++ b/test/unittest/test_watch_history_db.py
@@ -236,21 +236,24 @@ def test_update_item(mocked_watch_history_db):
     UPDATE_VALUES = {}
     mocked_watch_history_db.table.update_item = mock_func
 
-    mocked_watch_history_db.add_item(TEST_USERNAME, "MOVIE", "123123")
+    mocked_watch_history_db.update_item(TEST_USERNAME, "MOVIE", "123", {"review": "review_text"})
 
     assert UPDATE_VALUES == {
         'ExpressionAttributeNames': {
             '#collection_name': 'collection_name',
-            '#updated_at': 'updated_at'
+            '#updated_at': 'updated_at',
+            "#review": "review"
         },
         'ExpressionAttributeValues': {
             ':collection_name': 'MOVIE',
-            ":updated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            ":updated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            ":review": "review_text"
         },
         'Key': {
             'username': TEST_USERNAME,
-            'item_id': '123123'},
-        'UpdateExpression': 'SET #collection_name=:collection_name,#updated_at=:updated_at REMOVE deleted_at'
+            'item_id': '123'},
+        'UpdateExpression': 'SET #review=:review,#collection_name=:collection_name,'
+                            '#updated_at=:updated_at REMOVE deleted_at'
     }
 
 


### PR DESCRIPTION
* Make JSON schema property consistent and named `dates_watched` in both episode and item patch
* Get latest watch date during patch and update a new `latest_watch_date` property
* Add new `latest_watch_date` LSI indices to both episode and item dynamo 
