### PR TITLE
fix(api): replace Jikan with Tenrai for anime data

### DIFF
--- a/docs/includes/js/api/mal.js
+++ b/docs/includes/js/api/mal.js
@@ -3,7 +3,7 @@ import {MoshanItems, MoshanItem, MoshanEpisodes, MoshanEpisode} from './common.j
 export class MalApi {
   constructor () {
     this.apiAxios = axios.create({
-      baseURL: 'https://api.jikan.moe/v4/',
+      baseURL: 'https://api.tenrai.org/v1/',
     });
   }
 

--- a/src/lambdas/api/app/routes.py
+++ b/src/lambdas/api/app/routes.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 
 import dateutil.parser
-import jikan
 import reviews_db
+import tenrai
 import tmdb
 import tvmaze
 
@@ -10,7 +10,7 @@ from .models import ApiNameWithEpisodes
 
 tmdb_api = tmdb.TmdbApi()
 tvmaze_api = tvmaze.TvMazeApi()
-jikan_api = jikan.JikanApi()
+tenrai_api = tenrai.TenraiApi()
 
 
 def get_items(username, sort=None, cursor=None, filter=None):
@@ -66,7 +66,7 @@ def add_item(username, api_name, api_id, data):
         }
         ep_count_res = tvmaze_api.get_show_episodes_count(api_id)
     elif api_name == "mal":
-        api_item = jikan_api.get_item(api_id).get("data", {})
+        api_item = tenrai_api.get_item(api_id).get("data", {})
         api_cache = {
             "title": api_item.get("title"),
             "release_date": api_item.get("aired", {}).get("from"),
@@ -76,7 +76,7 @@ def add_item(username, api_name, api_id, data):
             .get("jpg", {})
             .get("image_url"),
         }
-        ep_count_res = jikan_api.get_episode_count(api_id)
+        ep_count_res = tenrai_api.get_episode_count(api_id)
 
     try:
         current_item = reviews_db.get_item(
@@ -150,7 +150,7 @@ def add_episode(
         api_res = tvmaze_api.get_episode(episode_api_id)
         is_special = api_res["type"] != "regular"
     elif api_name == ApiNameWithEpisodes.mal.value:
-        jikan_api.get_episode(item_api_id, episode_api_id)
+        tenrai_api.get_episode(item_api_id, episode_api_id)
         is_special = False  # mal items are special not episodes
 
     item = reviews_db.get_item(
@@ -183,7 +183,7 @@ def update_episode(
     if api_name == ApiNameWithEpisodes.tvmaze.value:
         tvmaze_api.get_episode(episode_api_id)
     elif api_name == ApiNameWithEpisodes.mal.value:
-        jikan_api.get_episode(item_api_id, episode_api_id)
+        tenrai_api.get_episode(item_api_id, episode_api_id)
 
     item = reviews_db.get_item(
         username,
@@ -232,7 +232,7 @@ def delete_episode(
         api_res = tvmaze_api.get_episode(episode_api_id)
         is_special = api_res["type"] != "regular"
     elif api_name == ApiNameWithEpisodes.mal.value:
-        jikan_api.get_episode(item_api_id, episode_api_id)
+        tenrai_api.get_episode(item_api_id, episode_api_id)
         is_special = False  # mal items are special not episodes
 
     reviews_db.delete_episode(

--- a/src/lambdas/updates_publisher/__init__.py
+++ b/src/lambdas/updates_publisher/__init__.py
@@ -1,5 +1,5 @@
-import jikan
 import reviews_db
+import tenrai
 import tmdb
 import tvmaze
 import updates
@@ -9,7 +9,7 @@ setup_logger()
 
 tmdb_api = tmdb.TmdbApi()
 tvmaze_api = tvmaze.TvMazeApi()
-jikan_api = jikan.JikanApi()
+tenrai_api = tenrai.TenraiApi()
 
 
 def handler(event, context):
@@ -50,7 +50,7 @@ def _check_tvmaze_updates():
 
 
 def _check_mal_updates():
-    airing = jikan_api.get_schedules()
+    airing = tenrai_api.get_schedules()
 
     for a in airing:
         mal_id = a["mal_id"]

--- a/src/lambdas/updates_subscriber/__init__.py
+++ b/src/lambdas/updates_subscriber/__init__.py
@@ -2,8 +2,8 @@ import json
 from datetime import datetime
 from decimal import Decimal
 
-import jikan
 import reviews_db
+import tenrai
 import tmdb
 import tvmaze
 from log import setup_logger
@@ -13,7 +13,7 @@ setup_logger()
 
 tmdb_api = tmdb.TmdbApi()
 tvmaze_api = tvmaze.TvMazeApi()
-jikan_api = jikan.JikanApi()
+tenrai_api = tenrai.TenraiApi()
 
 
 def handler(event, context):
@@ -45,11 +45,11 @@ def handler(event, context):
             "image_url": api_item.get("image", {}).get("original"),
         }
     elif api_name == "mal":
-        api_item = jikan_api.get_item(api_id).get("data", {})
+        api_item = tenrai_api.get_item(api_id).get("data", {})
         api_ep_count = api_item.get("episodes")
         if api_ep_count is None:
             api_ep_count = 0
-        episodes_info = jikan_api.get_episode_count(api_id)
+        episodes_info = tenrai_api.get_episode_count(api_id)
         ep_count = max(api_ep_count, episodes_info.get("ep_count", 0))
         api_cache = {
             "title": api_item.get("title"),

--- a/src/layers/api/tenrai.py
+++ b/src/layers/api/tenrai.py
@@ -6,9 +6,9 @@ import utils
 from loguru import logger
 
 
-class JikanApi:
+class TenraiApi:
     def __init__(self):
-        self.base_url = "https://api.jikan.moe/v4"
+        self.base_url = "https://api.tenrai.org/v1"
 
     def get_item(self, anime_id):
         return self._get(f"/anime/{anime_id}")
@@ -38,7 +38,7 @@ class JikanApi:
             last_id = 0
 
         # Hack for allowing to add 25 more episodes than currently present in
-        # api to quickfix slow api updates and jikan 24h cache
+        # api to quickfix slow api updates and tenrai 24h cache
         if last_id < int(episode_id) <= last_id + 25:
             return True
 

--- a/src/layers/api/utils.py
+++ b/src/layers/api/utils.py
@@ -30,14 +30,14 @@ class MediaRequestThread(Thread):
         self.show_api = show_api
 
     def run(self):
-        import jikan
+        import tenrai
         import tmdb
         import tvmaze
 
         api_map = {
             "tvmaze": tvmaze.TvMazeApi(),
             "tmdb": tmdb.TmdbApi(),
-            "mal": jikan.JikanApi(),
+            "mal": tenrai.TenraiApi(),
         }
 
         s = self.item["api_info"].split("_")

--- a/test/unittest/test_api_tenrai.py
+++ b/test/unittest/test_api_tenrai.py
@@ -1,5 +1,5 @@
 import pytest
-from jikan import JikanApi
+from tenrai import TenraiApi
 
 
 @pytest.fixture()
@@ -9,7 +9,7 @@ def mocked_send_request(mocker):
 
 @pytest.fixture()
 def mocked_api(mocked_send_request):
-    return JikanApi()
+    return TenraiApi()
 
 
 def _create_schedules_res(data, pages=2):


### PR DESCRIPTION
## Changes
- Replace Jikan API client with Tenrai (schema-compatible); Jikan has been intermittently returning 504s on item/episode lookups
- Point anime data source at https://api.tenrai.org/v1
- Update all lambdas, routes, tests, and docs JS client referencing jikan