### PR TITLE
fix(search): isolate per-source failures on the search page

### DIFF
--- a/docs/includes/js/results.js
+++ b/docs/includes/js/results.js
@@ -8,18 +8,16 @@ const urlParams = new URLSearchParams(window.location.search);
 const qParams = new QueryParams(urlParams);
 
 // Will be moved to profile settings in the future
-const animeApiName = 'mal';
-const showApiName = 'tvmaze';
-const movieApiName = 'tmdb';
-
-const animeApi = getApiByName(animeApiName);
-const showApi = getApiByName(showApiName);
-const movieApi = getApiByName(movieApiName);
+const searches = [
+  {apiName: 'mal', resultsElementId: 'animeResults'},
+  {apiName: 'tvmaze', resultsElementId: 'showResults'},
+  {apiName: 'tmdb', resultsElementId: 'movieResults'},
+];
 
 if (isLoggedIn()) {
-  document.getElementById('animeResults').innerHTML = '<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>';
-  document.getElementById('showResults').innerHTML = '<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>';
-  document.getElementById('movieResults').innerHTML = '<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>';
+  for (const {resultsElementId} of searches) {
+    document.getElementById(resultsElementId).innerHTML = '<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>';
+  }
 
   getResults();
 }
@@ -29,16 +27,24 @@ function QueryParams(urlParams) {
 }
 
 async function getResults() {
-  const animeMoshanItems = await animeApi.search(qParams);
-  const showMoshanItems = await showApi.search(qParams);
-  const movieMoshanItems = await movieApi.search(qParams);
-
-  createResults(animeMoshanItems, animeApiName);
-  createResults(showMoshanItems, showApiName);
-  createResults(movieMoshanItems, movieApiName);
+  // Each source is searched and rendered independently so one API failing
+  // (e.g. a non-2xx response) doesn't stop the others from showing results.
+  await Promise.all(searches.map(({apiName, resultsElementId}) =>
+    searchAndRender(apiName, resultsElementId)
+  ));
 }
 
-function createResults(moshanItems, apiName) {
+async function searchAndRender(apiName, resultsElementId) {
+  try {
+    const moshanItems = await getApiByName(apiName).search(qParams);
+    createResults(moshanItems, apiName, resultsElementId);
+  } catch (err) {
+    console.error(`Search failed for ${apiName}`, err);
+    document.getElementById(resultsElementId).innerHTML = '<p class="text-muted small">Search is unavailable right now.</p>';
+  }
+}
+
+function createResults(moshanItems, apiName, resultsElementId) {
   console.debug(moshanItems);
 
   let resultHTML = '';
@@ -54,5 +60,5 @@ function createResults(moshanItems, apiName) {
     `;
   }
 
-  document.getElementById(`${moshanItems.collection_name}Results`).innerHTML = resultHTML;
+  document.getElementById(resultsElementId).innerHTML = resultHTML;
 }


### PR DESCRIPTION
## Changes
- Search each source (mal/tenrai, tvmaze, tmdb) independently and catch errors per source, instead of one sequential await chain
- A failing/erroring source now shows an inline message in its own results section instead of leaving all three sections stuck on the loading spinner